### PR TITLE
Avoid error state in overlay js

### DIFF
--- a/js/overlay.js
+++ b/js/overlay.js
@@ -50,6 +50,32 @@ var showLargeImage = function(clickedLink) {
 		$('<img>').attr('src', largeSrc)
 	);
 };
+var populateOverlay = function (hiddenCarousel) {
+	if (!hiddenCarousel[0]) {
+		console.warn('no carousel found, cannot show large image.');
+		return;
+	};
+	$('#fancyoverlay')
+		.empty() // empty the overlay before putting more stuff into it
+		.show() // show it (it's hidden)
+		.html(template({
+			carouselHtml : hiddenCarousel[0] && hiddenCarousel[0].outerHTML
+		}))// fill it with the slick carousel created above
+		.find('.overlay-carousel')
+		.slick(opts); // invoke the slick carousel on the carousel html in there
+
+	// set up click event to populate the large size image when user clicks the carousel
+	$('#fancyoverlay a').click(function(e) {
+		e.preventDefault();
+		showLargeImage(this);
+	});
+
+	// set up click event for "x" button to empty out the fancy overlay box :
+	$('#fancyoverlay .close-button').click(function () {
+		$('#fancyoverlay').empty().hide();
+	});
+
+};
 
 $(document).ready(function() {
 
@@ -60,30 +86,7 @@ $(document).ready(function() {
 			.clone()
 			.addClass('overlay-carousel');
 
-		if (!hiddenCarousel[0]) {
-			console.warn('no carousel found, cannot show large image.');
-			return;
-		};
-		$('#fancyoverlay')
-			.empty() // empty the overlay before putting more stuff into it
-			.show() // show it (it's hidden)
-			.html(template({
-				carouselHtml : hiddenCarousel[0] && hiddenCarousel[0].outerHTML
-			}))// fill it with the slick carousel created above
-			.find('.overlay-carousel')
-			.slick(opts); // invoke the slick carousel on the carousel html in there
-
-		// set up click event to populate the large size image when user clicks the carousel
-		$('#fancyoverlay a').click(function(e) {
-			e.preventDefault();
-			showLargeImage(this);
-		});
-
-		// set up click event for "x" button to empty out the fancy overlay box :
-		$('#fancyoverlay .close-button').click(function () {
-			$('#fancyoverlay').empty().hide();
-		});
-
+		populateOverlay(hiddenCarousel);
 		// show the first of the large images :
 		showLargeImage($('#fancyoverlay a')[0]);
 	});

--- a/js/overlay.js
+++ b/js/overlay.js
@@ -40,6 +40,10 @@ var opts = {
 
 var template = _.template($('#fancyOverlay-template').html(), { variable : 'obj' });
 var showLargeImage = function(clickedLink) {
+	if (!clickedLink || ($(clickedLink).find('img').length === 0)) {
+		console.warn('no image found, cannot show large image.');
+		return;
+	};
 	var largeSrc = $(clickedLink).find('img').attr('src').replace('thumbs', 'large');
 
 	$('#fancyOverlay-large').html(
@@ -56,6 +60,10 @@ $(document).ready(function() {
 			.clone()
 			.addClass('overlay-carousel');
 
+		if (!hiddenCarousel[0]) {
+			console.warn('no carousel found, cannot show large image.');
+			return;
+		};
 		$('#fancyoverlay')
 			.empty() // empty the overlay before putting more stuff into it
 			.show() // show it (it's hidden)

--- a/js/overlay.js
+++ b/js/overlay.js
@@ -42,8 +42,10 @@ var template = _.template($('#fancyOverlay-template').html(), { variable : 'obj'
 var showLargeImage = function(clickedLink) {
 	if (!clickedLink || ($(clickedLink).find('img').length === 0)) {
 		console.warn('no image found, cannot show large image.');
+		closeOverlay();
 		return;
 	};
+
 	var largeSrc = $(clickedLink).find('img').attr('src').replace('thumbs', 'large');
 
 	$('#fancyOverlay-large').html(
@@ -53,8 +55,10 @@ var showLargeImage = function(clickedLink) {
 var populateOverlay = function (hiddenCarousel) {
 	if (!hiddenCarousel[0]) {
 		console.warn('no carousel found, cannot show large image.');
+		closeOverlay();
 		return;
 	};
+
 	$('#fancyoverlay')
 		.empty() // empty the overlay before putting more stuff into it
 		.show() // show it (it's hidden)
@@ -72,9 +76,12 @@ var populateOverlay = function (hiddenCarousel) {
 
 	// set up click event for "x" button to empty out the fancy overlay box :
 	$('#fancyoverlay .close-button').click(function () {
-		$('#fancyoverlay').empty().hide();
+		closeOverlay();
 	});
 
+};
+var closeOverlay = function () {
+	$('#fancyoverlay').empty().hide();
 };
 
 $(document).ready(function() {

--- a/retoucher.html
+++ b/retoucher.html
@@ -213,7 +213,7 @@
 
         <div><a href="#slickslider2" data-toggle="collapse">Editorial</a></div>
         <div id="slickslider2" class="collapse">
-            <div class="variable-width">
+            <div class="variable-width lightbox-thumbs">
                 <a href="images/EDITORIAL/ARISE/large/1.jpg" data-overlay-pointer="ARISE"><img src="images/EDITORIAL/ARISE/thumbs/1.jpg" /></a>
                 <a href="images/EDITORIAL/ELLEUK/large/2.jpg" data-overlay-pointer="ELLEUK"><img src="images/EDITORIAL/ELLEUK/thumbs/2.jpg" /></a>
                 <a href="images/EDITORIAL/ESSENCE/large/4.jpg" data-overlay-pointer="ESSENCE"><img src="images/EDITORIAL/ESSENCE/thumbs/4.jpg" /></a>
@@ -253,7 +253,7 @@
 
         <div><a href="#slickslider3" data-toggle="collapse">Celebrity</a></div>
         <div id="slickslider3" class="collapse">
-            <div class="variable-width">
+            <div class="variable-width lightbox-thumbs">
                 <a href="images/CELEBRITY/COMPLEX-JESSIEJ/large/3.jpg" data-overlay-pointer="COMPLEX-JESSIEJ"><img src="images/CELEBRITY/COMPLEX-JESSIEJ/thumbs/3.jpg" /></a>
                 <a href="images/CELEBRITY/COMPLEX-KELLYROWLAND/large/5.jpg" data-overlay-pointer="COMPLEX-KELLYROWLAND"><img src="images/CELEBRITY/COMPLEX-KELLYROWLAND/thumbs/5.jpg" /></a>
                 <a href="images/CELEBRITY/COMPLEX-MARYELIZABETHWINSTEAD/large/4.jpg" data-overlay-pointer="COMPLEX-MARYELIZABETHWINSTEAD"><img src="images/CELEBRITY/COMPLEX-MARYELIZABETHWINSTEAD/thumbs/4.jpg" /></a>
@@ -275,7 +275,7 @@
         </div>
         <div><a href="#slickslider4" data-toggle="collapse">Accesories/Still</a></div>
         <div id="slickslider4" class="collapse">
-            <div class="variable-width">
+            <div class="variable-width lightbox-thumbs">
 
                 <a href="images/ACCESSORIES-STILL/ELLEUK/large/1.jpg" data-overlay-pointer="ACCESSORIESELLEUK"><img src="images/ACCESSORIES-STILL/ELLEUK/thumbs/1.jpg" /></a><a href="images/ACCESSORIES-STILL/ESSENCE/thumbs/1.jpg" data-overlay-pointer="ACCESSORIESESSENCE"><img src="images/ACCESSORIES-STILL/ESSENCE/thumbs/1.jpg" /></a>
                 <a href="images/ACCESSORIES-STILL/GLAMOURITALIA/large/5.jpg" data-overlay-pointer="GLAMOURITALIA"><img src="images/ACCESSORIES-STILL/GLAMOURITALIA/thumbs/5.jpg" /></a>
@@ -299,7 +299,7 @@
 
         <div><a href="#slickslider5" data-toggle="collapse">Hair</a></div>
         <div id="slickslider5" class="collapse">
-            <div class="variable-width">
+            <div class="variable-width lightbox-thumbs">
 
                 <a href="images/HAIR/JCPSALON-INSTYLE/large/1.jpg" data-overlay-pointer="JCPSALON-INSTYLE"><img src="images/HAIR/JCPSALON-INSTYLE/thumbs/1.jpg" /></a>
                 <a href="images/HAIR/JCPSALON-INSTYLE/large/2.jpg" data-overlay-pointer="JCPSALON-INSTYLE"><img src="images/HAIR/JCPSALON-INSTYLE/thumbs/2.jpg" /></a>
@@ -336,7 +336,7 @@
 
         <div><a href="#slickslider6" data-toggle="collapse"></a></div>
         <div id="slickslider6" class="collapse">
-            <div class="variable-width">
+            <div class="variable-width lightbox-thumbs">
 
                 <a href="images/WEB/INSTYLE1/large/2.jpg" data-overlay-pointer="WEBINSTYLE1"><img src="images/WEB/INSTYLE1/thumbs/2.jpg" /></a>
                 <a href="images/WEB/INSTYLE2/large/3.jpg" data-overlay-pointer="WEBINSTYLE2"><img src="images/WEB/INSTYLE2/thumbs/3.jpg" /></a>
@@ -347,7 +347,7 @@
 
         <div><a href="#slickslider7" data-toggle="collapse">PORTRAITURE</a></div>
         <div id="slickslider7" class="collapse">
-            <div class="variable-width">
+            <div class="variable-width lightbox-thumbs">
 
                 <a href="images/PORTRAITURE/INSTYLE/large/10.jpg" data-overlay-pointer="PORTRAITUREINSTYLE"><img src="images/PORTRAITURE/INSTYLE/thumbs/10.jpg" /></a>
                 <a href="images/PORTRAITURE/MORE/large/6.jpg" data-overlay-pointer="PORTRAITUREMORE"><img src="images/PORTRAITURE/MORE/thumbs/6.jpg" /></a>
@@ -358,7 +358,7 @@
 
         <div><a href="#slickslider8" data-toggle="collapse">Advertising</a></div>
         <div id="slickslider8" class="collapse">
-            <div class="variable-width">
+            <div class="variable-width lightbox-thumbs">
                 <a href="images/ADVERTISING/AVON/large/1.jpg" data-overlay-pointer="ADVERTISINGAVON"><img src="images/ADVERTISING/AVON/thumbs/1.jpg" /></a>
                 <a href="images/ADVERTISING/BLOOMINGDALES/large/1.jpg" data-overlay-pointer="BLOOMINGDALES"><img src="images/ADVERTISING/BLOOMINGDALES/thumbs/1.jpg" /></a>
                 <a href="images/ADVERTISING/BOMBERG/large/15.jpg" data-overlay-pointer="BOMBERG"><img src="images/ADVERTISING/BOMBERG/thumbs/15.jpg" /></a>
@@ -385,7 +385,7 @@
 
         <a href="#slickslider9" data-toggle="collapse">Architecture/Interiors</a>
         <div id="slickslider9" class="collapse">
-            <div class="variable-width">
+            <div class="variable-width lightbox-thumbs">
                 <div><a href="images/ARCHITECTURE-INTERIORS/departures/large/1.jpg" data-overlay-pointer="DEPARTURES"><img src="images/ARCHITECTURE-INTERIORS/departures/thumbs/1.jpg" /></a></div>
                 <div><a href="images/ARCHITECTURE-INTERIORS/departures/large/2.jpg" data-overlay-pointer="DEPARTURES"><img src="images/ARCHITECTURE-INTERIORS/departures/thumbs/2.jpg" /></a></div>
                 <div><a href="images/ARCHITECTURE-INTERIORS/departures/large/3.jpg" data-overlay-pointer="DEPARTURES"><img src="images/ARCHITECTURE-INTERIORS/departures/thumbs/3.jpg" /></a></div>


### PR DESCRIPTION
@Phillipe-Bojorquez check this shiz out. If there is no hidden carousel or first image, don't just bomb out, instead hide the whole overlay and throw console warnings. 

This way improperly formatted html will not break the page. 